### PR TITLE
Add Jest tests for game logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # RockPaperScissors
+
+This project implements a simple rock–paper–scissors game in the browser.
+
+## Running the tests
+
+The project uses [Jest](https://jestjs.io/) with JSDOM. To run the test suite:
+
+```bash
+npm test
+```
+
+This will execute all files in the `__tests__` directory.

--- a/__tests__/game.test.js
+++ b/__tests__/game.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('Rock Paper Scissors game', () => {
+  let dom;
+  let document;
+  let play;
+
+  beforeEach(() => {
+    const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+    dom = new JSDOM(html, { runScripts: 'dangerously' });
+    document = dom.window.document;
+    dom.window.HTMLMediaElement.prototype.play = jest.fn();
+    play = dom.window.play;
+    jest.spyOn(global.Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('play updates win/lose/draw counts and win rate', () => {
+    play('rock');
+    expect(document.getElementById('win-count').textContent).toBe('0');
+    expect(document.getElementById('lose-count').textContent).toBe('0');
+    expect(document.getElementById('draw-count').textContent).toBe('1');
+    expect(document.getElementById('win-rate').textContent).toBe('0.00%');
+
+    play('paper');
+    expect(document.getElementById('win-count').textContent).toBe('1');
+    expect(document.getElementById('lose-count').textContent).toBe('0');
+    expect(document.getElementById('draw-count').textContent).toBe('1');
+    expect(document.getElementById('win-rate').textContent).toBe('50.00%');
+
+    play('scissors');
+    expect(document.getElementById('win-count').textContent).toBe('1');
+    expect(document.getElementById('lose-count').textContent).toBe('1');
+    expect(document.getElementById('draw-count').textContent).toBe('1');
+    expect(document.getElementById('win-rate').textContent).toBe('33.33%');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rockpaperscissors",
+  "version": "1.0.0",
+  "description": "Rock Paper Scissors game",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^23.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest and jsdom
- write unit tests for game logic
- document test instructions in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f861cd550832383880916159e46f4